### PR TITLE
Fixes #7

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -11,7 +11,7 @@
   },
 
   "background": {
-    "scripts": ["src/js/jquery/jquery.js","src/background.js", "src/js/aes-js/index.js"],
+    "scripts": ["src/js/jquery/jquery.js","src/background.js"],
     "persistent": true
   },
   "browser_action": {


### PR DESCRIPTION
AES-JS is not currently needed. May incorporate for future work where AJAX is encrypted.